### PR TITLE
feat(layout): implement responsive UI across main views

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -28,7 +28,7 @@ import Navbar from "@/components/layout/NavbarGuest";
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background-color)]">
+    <div className="flex flex-col items-center justify-center bg-[var(--background-color)]">
       <Navbar />
       <LoginForm />
     </div>

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -29,7 +29,7 @@ import Navbar from "@/components/layout/NavbarGuest";
 
 export default function RegisterPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background-color)]">
+    <div className="flex flex-col items-center justify-center bg-[var(--background-color)]">
       <Navbar />
       <RegisterForm />
     </div>

--- a/src/app/dashboard/components/AnswerCard.tsx
+++ b/src/app/dashboard/components/AnswerCard.tsx
@@ -115,7 +115,7 @@ const InfoBlock = ({
 }) => {
   const IconComponent = iconMap[icon];
   return (
-    <div className="relative group h-full">
+    <div className="relative group h-full max-sm:w-full">
       <div
         className={`absolute -inset-0.5 bg-gradient-to-r ${colorClass} rounded-xl blur opacity-30 group-hover:opacity-60 transition-opacity duration-300`}
       />
@@ -148,7 +148,7 @@ export function AnswerCard({ answer }: { answer: UserAnswer }) {
       icon: "Target" as IconName,
       title: "Objetivo",
       value: goalMap[answer.goal] || answer.goal,
-      color: "from-blue-500 to-cyan-500",
+      color: "from-blue-500 to-blue-700",
     },
     {
       type: "experience",
@@ -157,47 +157,47 @@ export function AnswerCard({ answer }: { answer: UserAnswer }) {
       value:
         trainingExperienceMap[answer.training_experience] ||
         answer.training_experience,
-      color: "from-purple-500 to-blue-500",
+      color: "from-purple-500 to-purple-700",
     },
     {
       type: "fitness",
       icon: "Gauge" as IconName,
       title: "Nivel Físico",
       value: fitnessLevelMap[answer.fitness_level] || answer.fitness_level,
-      color: "from-orange-500 to-red-500",
+      color: "from-orange-500 to-orange-700",
     },
     {
       type: "availability",
       icon: "CalendarDays" as IconName,
       title: "Disponibilidad",
       value: `${answer.availability} días/semana`,
-      color: "from-green-500 to-emerald-500",
+      color: "from-green-500 to-green-700",
     },
     {
       type: "duration",
       icon: "Timer" as IconName,
       title: "Duración Sesión",
       value: formatSessionDuration(answer.session_duration),
-      color: "from-indigo-500 to-purple-500",
+      color: "from-indigo-500 to-indigo-700",
     },
     {
       type: "injuries",
       icon: "HeartPulse" as IconName,
       title: "Lesiones",
       value: formatInjuries(answer.injuries),
-      color: "from-red-500 to-pink-500",
+      color: "from-red-500 to-red-700",
     },
     {
       type: "equipment",
       icon: "Dumbbell" as IconName,
       title: "Acceso a Equipo",
       value: answer.equipment_access ? "Gimnasio" : "En casa",
-      color: "from-emerald-500 to-teal-500",
+      color: "from-pink-500 to-pink-700",
     },
   ];
 
   return (
-    <Card className="w-full mb-4 bg-slate-900/50 backdrop-blur-xl border border-slate-700/50 shadow-2xl rounded-2xl">
+    <Card className="w-full mb-4 bg-slate-900/50 border border-slate-700/50 shadow-2xl rounded-2xl">
       <CardHeader className="pb-4">
         <CardTitle className="flex items-center gap-3 text-3xl font-bold text-white">
           <Activity className="h-8 w-8 text-cyan-400" />
@@ -210,17 +210,31 @@ export function AnswerCard({ answer }: { answer: UserAnswer }) {
       </CardHeader>
 
       <CardContent>
-        <div className="flex flex-wrap justify-center gap-12">
-          {profileData.map((item) => (
-            <InfoBlock
-              key={item.title}
-              icon={item.icon}
-              title={item.title}
-              value={item.value}
-              colorClass={item.color}
-              type={item.type}
-            />
-          ))}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+          {profileData.map((item, index) => {
+            // 1. Comprobamos si este es el último elemento del array
+            const isLastItem = index === profileData.length - 1;
+
+            return (
+              // 2. Envolvemos el InfoBlock para aplicar la clase condicional
+              <div
+                key={item.title}
+                className={
+                  isLastItem
+                    ? "sm:col-span-2" // Si es el último, ocupa todas las columnas
+                    : "" // Si no, no aplicamos ninguna clase extra de span
+                }
+              >
+                <InfoBlock
+                  icon={item.icon}
+                  title={item.title}
+                  value={item.value}
+                  colorClass={item.color}
+                  type={item.type}
+                />
+              </div>
+            );
+          })}
         </div>
       </CardContent>
     </Card>

--- a/src/app/dashboard/components/QuestionAnswerCard.tsx
+++ b/src/app/dashboard/components/QuestionAnswerCard.tsx
@@ -1,6 +1,5 @@
 // src/app/dashboard/components/QuestionAnswerCard.tsx
 
-"use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,7 +9,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex">
+    <div className="bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))] flex pb-20 md:pb-0">
       <Sidebar />
       <main className="flex-1">{children}</main>
     </div>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,5 +1,4 @@
 // app/dashboard/layout.tsx
-"use client";
 
 import React from "react";
 import Sidebar from "@/components/layout/Aside"; // confirma que en tu filesystem exista components/Sidebar.tsx

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -35,7 +35,7 @@ export default function DashboardPage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center min-h-screen bg-slate-950">
+      <div className="flex justify-center items-center bg-slate-950">
         <LoadingSpinner />
       </div>
     );
@@ -43,7 +43,7 @@ export default function DashboardPage() {
 
   if (error) {
     return (
-      <div className="flex justify-center items-center min-h-screen bg-slate-950 p-4">
+      <div className="flex justify-center items-center bg-slate-950 p-4">
         <p className="text-center text-red-500 font-semibold">
           No se pudo cargar tu perfil: {error.message}
         </p>
@@ -54,7 +54,7 @@ export default function DashboardPage() {
   const latestAnswer = answers?.[0];
 
   return (
-    <div className="bg-slate-950 text-slate-50 min-h-screen">
+    <div className=" text-slate-50">
       <div className="max-w-7xl mx-auto p-4 md:p-8 space-y-8 md:space-y-10">
         {/* ===== 1. CABECERA RESPONSIVE ===== */}
         <header className="flex flex-col gap-4 md:flex-row md:justify-between md:items-start">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,14 +44,14 @@ function TodayRoutine() {
   return (
     <div className="w-full flex flex-col justify-between p-8 border border-slate-800 rounded-2xl bg-slate-900 shadow-lg h-full hover:border-cyan-500/50 transition-colors duration-300">
       <div>
-        <h2 className="text-3xl font-bold text-white mb-2">Today's Routine</h2>
+        <h2 className="text-3xl font-bold text-white mb-2">Rutina diaria</h2>
         <p className="text-slate-400 mb-6">
-          Your personalized plan is ready. Let’s get to it!
+          Tu plan personalizado está listo. ¡Vamos a ello!
         </p>
       </div>
       <Link href="/routine" passHref>
         <button className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-cyan-500 text-slate-900 font-semibold rounded-lg transition-transform hover:scale-105 shadow-md hover:shadow-cyan-500/30">
-          Start Training <ArrowRight className="w-5 h-5" />
+          Iniciar entrenamiento <ArrowRight className="w-5 h-5" />
         </button>
       </Link>
     </div>
@@ -73,7 +73,7 @@ export default function DashboardPage() {
     return (
       <div className="flex justify-center items-center h-screen bg-slate-950">
         <p className="text-center text-red-500 font-semibold">
-          Failed to load your profile: {error.message}
+          No se pudo cargar tu perfil: {error.message}
         </p>
       </div>
     );
@@ -90,7 +90,7 @@ export default function DashboardPage() {
               Dashboard
             </h1>
             <p className="text-slate-400 mt-2">
-              Welcome back. Here’s your progress and today’s routine.
+              Bienvenido de vuelta. Aquí está tu progreso y tu rutina diaria.
             </p>
           </div>
 
@@ -106,15 +106,14 @@ export default function DashboardPage() {
             <div className="h-full flex items-center justify-center p-8 border border-dashed border-slate-700 rounded-2xl">
               <div className="text-center">
                 <h2 className="text-2xl font-semibold text-white mb-2">
-                  Welcome to your Dashboard!
+                  Bienvenido a tu Dashboard!
                 </h2>
                 <p className="text-slate-400 mb-4">
-                  It looks like you haven't completed our initial questionnaire
-                  yet.
+                  Parece que aún no has completado nuestro cuestionario inicial.
                 </p>
                 <Link href="/quiz" passHref>
                   <Button className="bg-cyan-500 hover:bg-cyan-600 text-slate-900">
-                    Create My Training Plan
+                    Crear mi plan de entrenamiento
                   </Button>
                 </Link>
               </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,27 +1,3 @@
-/**
- * Renders the main dashboard page for authenticated users.
- *
- * This page displays a personalized summary and daily routine, using data fetched from the user's latest answers.
- * It includes conditional rendering of a profile card, an edit button, and a motivational "Today Routine" section.
- *
- * @remarks
- * The page uses a custom `useUserAnswers` hook (with SWR) to fetch the latest user data.
- * It shows different UI states depending on loading, error, or absence of user data.
- * Styling is applied using Tailwind CSS with dark mode enabled.
- *
- * @example
- * ```tsx
- * // Accessing /dashboard will render this page.
- * ```
- *
- * @returns A React element that represents the dashboard page UI.
- *
- * @see {@link useUserAnswers} - Custom hook for fetching and mutating user answer data.
- * @see {@link AnswerCard} - Displays the user's latest questionnaire result.
- * @see {@link EditAnswer} - Allows editing the latest answer.
- * @see {@link TodayRoutine} - Motivational CTA component rendered if data exists.
- */
-
 "use client";
 
 import { useUserAnswers } from "@/hooks/useUserAnswers";
@@ -32,19 +8,15 @@ import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-/**
- * `TodayRoutine` is a visual call-to-action component that promotes the user's daily training plan.
- *
- * It includes a motivational message and a link to the `/routine` page styled as a full-width button.
- * This component is shown only when the user has completed their initial questionnaire.
- *
- * @returns A React element encouraging the user to begin their daily workout.
- */
 function TodayRoutine() {
+  // Este componente interno ya es bastante responsive con w-full y h-full,
+  // se adaptará bien a nuestro nuevo grid.
   return (
-    <div className="w-full flex flex-col justify-between p-8 border border-slate-800 rounded-2xl bg-slate-900 shadow-lg h-full hover:border-cyan-500/50 transition-colors duration-300">
+    <div className="w-full flex flex-col justify-between p-6 md:p-8 border border-slate-800 rounded-2xl bg-slate-900 shadow-lg h-full hover:border-cyan-500/50 transition-colors duration-300">
       <div>
-        <h2 className="text-3xl font-bold text-white mb-2">Rutina diaria</h2>
+        <h2 className="text-2xl md:text-3xl font-bold text-white mb-2">
+          Rutina diaria
+        </h2>
         <p className="text-slate-400 mb-6">
           Tu plan personalizado está listo. ¡Vamos a ello!
         </p>
@@ -63,7 +35,7 @@ export default function DashboardPage() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center h-screen bg-slate-950">
+      <div className="flex justify-center items-center min-h-screen bg-slate-950">
         <LoadingSpinner />
       </div>
     );
@@ -71,7 +43,7 @@ export default function DashboardPage() {
 
   if (error) {
     return (
-      <div className="flex justify-center items-center h-screen bg-slate-950">
+      <div className="flex justify-center items-center min-h-screen bg-slate-950 p-4">
         <p className="text-center text-red-500 font-semibold">
           No se pudo cargar tu perfil: {error.message}
         </p>
@@ -83,10 +55,14 @@ export default function DashboardPage() {
 
   return (
     <div className="bg-slate-950 text-slate-50 min-h-screen">
-      <div className="max-w-7xl mx-auto p-4 md:p-8 space-y-10">
-        <header className="flex justify-between items-start gap-4">
+      <div className="max-w-7xl mx-auto p-4 md:p-8 space-y-8 md:space-y-10">
+        {/* ===== 1. CABECERA RESPONSIVE ===== */}
+        <header className="flex flex-col gap-4 md:flex-row md:justify-between md:items-start">
+          {/* - flex-col: En móvil, el título y el botón se apilan.
+              - md:flex-row: En pantallas medianas y más, vuelven a estar en fila.
+          */}
           <div>
-            <h1 className="text-4xl font-bold tracking-tight text-white">
+            <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-white">
               Dashboard
             </h1>
             <p className="text-slate-400 mt-2">
@@ -99,14 +75,28 @@ export default function DashboardPage() {
           )}
         </header>
 
-        <main className="flex flex-col gap-8 items-start">
+        {/* ===== 2. CONTENIDO PRINCIPAL CON GRID RESPONSIVE ===== */}
+        <main className="flex flex-col gap-20 items-start">
+          {/* - grid-cols-1: En móvil, una sola columna (las tarjetas se apilan).
+              - lg:grid-cols-2: En pantallas grandes, dos columnas (las tarjetas se ponen lado a lado).
+              - gap-8: Espacio entre las tarjetas.
+              - items-start: Alinea las tarjetas en la parte superior de su celda del grid.
+          */}
           {latestAnswer ? (
-            <AnswerCard answer={latestAnswer} />
+            <>
+              <div className="flex flex-col w-full">
+                <AnswerCard answer={latestAnswer} />
+                <TodayRoutine />
+              </div>
+            </>
           ) : (
-            <div className="h-full flex items-center justify-center p-8 border border-dashed border-slate-700 rounded-2xl">
+            // Mensaje de bienvenida que ocupa todo el ancho
+            <div className="h-full flex items-center justify-center p-8 border border-dashed border-slate-700 rounded-2xl lg:col-span-2">
+              {/* - lg:col-span-2: Le decimos que ocupe las 2 columnas del grid en pantallas grandes.
+               */}
               <div className="text-center">
                 <h2 className="text-2xl font-semibold text-white mb-2">
-                  Bienvenido a tu Dashboard!
+                  ¡Bienvenido a tu Dashboard!
                 </h2>
                 <p className="text-slate-400 mb-4">
                   Parece que aún no has completado nuestro cuestionario inicial.
@@ -119,8 +109,6 @@ export default function DashboardPage() {
               </div>
             </div>
           )}
-
-          {latestAnswer && <TodayRoutine />}
         </main>
       </div>
     </div>

--- a/src/app/groups/layout.tsx
+++ b/src/app/groups/layout.tsx
@@ -9,9 +9,9 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex">
+    <div className="flex">
       <Sidebar />
-      <main className="flex-1 bg-slate-950 text-slate-50 min-h-screen bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
+      <main className="flex-1 pb-20 md:pb-0 bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
         {children}
       </main>
     </div>

--- a/src/app/groups/layout.tsx
+++ b/src/app/groups/layout.tsx
@@ -1,5 +1,4 @@
 // app/dashboard/layout.tsx
-"use client";
 
 import React from "react";
 import Sidebar from "@/components/layout/Aside"; // confirma que en tu filesystem exista components/Sidebar.tsx

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import CommunityPage from "@/app/groups/components/Community";
 
 export default function GroupsPage() {

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,7 +2,7 @@ import CommunityPage from "@/app/groups/components/Community";
 
 export default function GroupsPage() {
   return (
-    <div className="bg-slate-950 text-slate-50 min-h-screen">
+    <div className="text-slate-50">
       <CommunityPage />
     </div>
   );

--- a/src/app/profile/components/UserInfo.tsx
+++ b/src/app/profile/components/UserInfo.tsx
@@ -96,7 +96,7 @@ export default function ProfilePage() {
   if (error) {
     return (
       <p className="text-center mt-20 text-red-500">
-        Failed to load profile: {error.message}
+        No se pudo cargar tu perfil: {error.message}
       </p>
     );
   }
@@ -104,7 +104,7 @@ export default function ProfilePage() {
   if (!user || !profile) {
     return (
       <p className="text-center mt-20 text-slate-400">
-        User profile not found.
+        No se encontró tu perfil.
       </p>
     );
   }
@@ -114,11 +114,11 @@ export default function ProfilePage() {
       <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
         <header className="mb-10">
           <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-white">
-            Your Profile
+            Tu Perfil
           </h1>
           <p className="text-slate-400 mt-2 max-w-2xl">
-            Manage your personal info, update your avatar, and review your
-            account details.
+            Gestiona tu información personal, actualiza tu avatar y revisa tus
+            detalles de cuenta.
           </p>
         </header>
 
@@ -141,7 +141,7 @@ export default function ProfilePage() {
             <Card className="w-full bg-slate-900/50 backdrop-blur-xl border border-slate-700/50 shadow-2xl rounded-2xl">
               <CardHeader>
                 <CardTitle className="text-2xl text-white">
-                  Account Details
+                  Detalles de la cuenta
                 </CardTitle>
                 <Separator className="mt-2 bg-slate-700/50" />
               </CardHeader>
@@ -157,8 +157,8 @@ export default function ProfilePage() {
                 />
                 <InfoRow
                   icon={<CalendarClock size={20} />}
-                  label="Member Since"
-                  value={new Date(user.created_at).toLocaleDateString("en-GB", {
+                  label="Miembro desde"
+                  value={new Date(user.created_at).toLocaleDateString("es-ES", {
                     year: "numeric",
                     month: "long",
                     day: "numeric",

--- a/src/app/profile/components/UserInfo.tsx
+++ b/src/app/profile/components/UserInfo.tsx
@@ -110,7 +110,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="bg-slate-950 text-slate-50 min-h-screen">
+    <div className="text-slate-50">
       <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
         <header className="mb-10">
           <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-white">

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -9,9 +9,11 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex">
+    <div className="flex pb-20 md:pb-0">
       <Sidebar />
-      <main className="flex-1 bg-slate-950">{children}</main>
+      <main className="flex-1 bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,5 +1,4 @@
 // app/dashboard/layout.tsx
-"use client";
 
 import React from "react";
 import Sidebar from "@/components/layout/Aside"; // confirma que en tu filesystem exista components/Sidebar.tsx

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import UserInfo from "@/app/profile/components/UserInfo";
 
 export default function ProfilePage() {

--- a/src/app/progress/components/ProgressList.tsx
+++ b/src/app/progress/components/ProgressList.tsx
@@ -51,11 +51,11 @@ export default function ProgressList({
   };
 
   if (!session) {
-    return <p>Please log in to view your progress.</p>;
+    return <p>Por favor inicia sesión para ver tu progreso.</p>;
   }
 
   if (error) {
-    return <p>Error loading progress: {error}</p>;
+    return <p>Error cargando progreso: {error}</p>;
   }
 
   return (
@@ -164,7 +164,7 @@ export default function ProgressList({
                             </span>
                             <span className="text-gray-500 dark:text-gray-400">
                               {" "}
-                              - {seriesData.length} sets
+                              - {seriesData.length} series
                               <div className="mt-2 pl-4 text-sm text-gray-500 dark:text-gray-400">
                                 <p>
                                   <span className="font-medium text-gray-400 dark:text-gray-300">
@@ -176,7 +176,7 @@ export default function ProgressList({
                                 </p>
                                 <p>
                                   <span className="font-medium text-gray-400 dark:text-gray-300">
-                                     Peso (kg):
+                                    Peso (kg):
                                   </span>{" "}
                                   {seriesData.map((s) => s.weight).join(" - ")}
                                 </p>

--- a/src/app/progress/components/ProgressList.tsx
+++ b/src/app/progress/components/ProgressList.tsx
@@ -61,13 +61,13 @@ export default function ProgressList({
   return (
     <div className="container mx-auto p-4 md:p-8">
       <h1 className="text-3xl font-bold mb-6 text-white dark:text-gray-100">
-        Workout History
+        Historial de entrenamientos
       </h1>
 
       {results.length === 0 ? (
         <p className="text-white dark:text-gray-400">
-          You haven't completed any routines yet. Start one to see your
-          progress!
+          No has completado ninguna rutina todavía. Inicia una para ver tu
+          progreso!
         </p>
       ) : (
         <div className="space-y-4">
@@ -101,9 +101,9 @@ export default function ProgressList({
                         {result.routine_name || "Unnamed Routine"}
                       </h2>
                       <p className="text-sm text-white dark:text-gray-400 mt-1">
-                        Completed on:{" "}
+                        Completado el:{" "}
                         {new Date(result.completed_at).toLocaleDateString(
-                          "en-US",
+                          "es-ES",
                           {
                             weekday: "long",
                             year: "numeric",
@@ -139,7 +139,7 @@ export default function ProgressList({
                     }`}
                   >
                     <h3 className="font-semibold text-white dark:text-gray-200 mb-2">
-                      Exercises Performed ({exercisesData.length})
+                      Ejercicios Realizados ({exercisesData.length})
                     </h3>
                     <ul className="space-y-2">
                       {exercisesData.map((exercise) => {
@@ -168,7 +168,7 @@ export default function ProgressList({
                               <div className="mt-2 pl-4 text-sm text-gray-500 dark:text-gray-400">
                                 <p>
                                   <span className="font-medium text-gray-400 dark:text-gray-300">
-                                    Reps:
+                                    Repeticiones:
                                   </span>{" "}
                                   {seriesData
                                     .map((s) => s.actualReps)
@@ -176,7 +176,7 @@ export default function ProgressList({
                                 </p>
                                 <p>
                                   <span className="font-medium text-gray-400 dark:text-gray-300">
-                                    Weights (kg):
+                                     Peso (kg):
                                   </span>{" "}
                                   {seriesData.map((s) => s.weight).join(" - ")}
                                 </p>

--- a/src/app/progress/layout.tsx
+++ b/src/app/progress/layout.tsx
@@ -1,6 +1,4 @@
 // app/dashboard/layout.tsx
-"use client";
-
 import React from "react";
 import Sidebar from "@/components/layout/Aside"; // confirma que en tu filesystem exista components/Sidebar.tsx
 

--- a/src/app/progress/layout.tsx
+++ b/src/app/progress/layout.tsx
@@ -8,9 +8,9 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex">
+    <div className="bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))] flex pb-20 md:pb-0">
       <Sidebar />
-      <main className="flex-1 bg-slate-950">{children}</main>
+      <main className="flex-1">{children}</main>
     </div>
   );
 }

--- a/src/app/questionnaire/components/QuestionnarieForm.tsx
+++ b/src/app/questionnaire/components/QuestionnarieForm.tsx
@@ -250,7 +250,7 @@ export default function QuestionnaireForm() {
   };
 
   return (
-    <div className="bg-slate-950 min-h-screen p-4 sm:p-6 flex items-center justify-center">
+    <div className="bg-slate-950 p-4 sm:p-6 flex items-center justify-center">
       <Card className="w-full max-w-2xl bg-slate-900/50 backdrop-blur-xl border border-slate-700/50 shadow-2xl rounded-2xl">
         <form onSubmit={handleSubmit}>
           {/* MEJORA VISUAL: Cabecera más impactante */}

--- a/src/app/questionnaire/page.tsx
+++ b/src/app/questionnaire/page.tsx
@@ -3,7 +3,7 @@ import QuestionnarieForm from "@/app/questionnaire/components/QuestionnarieForm"
 
 export default function FormPage() {
   return (
-    <div className="h-screen bg-[var(--background-color)]">
+    <div className="pb-20 md:pb-0 bg-[var(--background-color)]">
       <Navbar />
       <QuestionnarieForm />
     </div>

--- a/src/app/routine/components/CustomRoutineRunner.tsx
+++ b/src/app/routine/components/CustomRoutineRunner.tsx
@@ -251,7 +251,7 @@ export function RoutineRunner({ routine }: RoutineRunnerProps) {
       <button
         onClick={handleSubmit}
         disabled={isSubmitting}
-        className="mt-8 w-full px-6 py-3 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+        className="mt-8 w-full px-6 py-3 max-md:mb-16 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
       >
         {isSubmitting ? "Enviando..." : "Finalizar rutina"}
       </button>

--- a/src/app/routine/components/RoutineList.tsx
+++ b/src/app/routine/components/RoutineList.tsx
@@ -45,13 +45,13 @@ export default function RoutineList({ answerId }: RoutineListProps) {
 
   if (error)
     return (
-      <p className="text-red-500">Error loading routines: {error.message}</p>
+      <p className="text-red-500">Error cargando rutinas: {error.message}</p>
     );
   if (isLoading) return <LoadingSpinner />;
   if (!data || data.length === 0)
     return (
       <p className="text-gray-400">
-        No routines found. Try generating a new plan.
+        No se encontraron rutinas. Intenta generar un nuevo plan.
       </p>
     );
 

--- a/src/app/routine/components/RoutineList.tsx
+++ b/src/app/routine/components/RoutineList.tsx
@@ -19,7 +19,6 @@
 "use client";
 
 import useSWR from "swr";
-import { useState } from "react";
 import type { Routine } from "@/app/api/recommend-routines-by-answer/route";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { DeleteRoutineButton } from "@/app/routine/components/DeleteRoutineButton";

--- a/src/app/routine/components/RoutineList.tsx
+++ b/src/app/routine/components/RoutineList.tsx
@@ -61,7 +61,7 @@ export default function RoutineList({ answerId }: RoutineListProps) {
   return (
     <>
       <h2 className="text-2xl font-semibold text-white mb-2">
-        Recommended Routines
+        Rutinas recomendadas
       </h2>
       <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
         {data.map((routine) => (
@@ -88,13 +88,13 @@ export default function RoutineList({ answerId }: RoutineListProps) {
             <div className="mt-auto flex justify-between items-end">
               <div>
                 <p className="text-sm text-gray-300">
-                  🏋️ Exercises:{" "}
+                  🏋️ Ejercicios:{" "}
                   <span className="font-medium text-white">
                     {routine.exercises.length}
                   </span>
                 </p>
                 <p className="text-sm text-gray-400 mt-1">
-                  💪 Muscles:{" "}
+                  💪 Musculos:{" "}
                   {Array.from(
                     new Set(
                       routine.exercises.map((e: any) =>
@@ -111,7 +111,7 @@ export default function RoutineList({ answerId }: RoutineListProps) {
                 }
                 className="border border-gray-700 bg-gray-900 hover:bg-green-600 hover:text-white justify-self-end flex"
               >
-                Start
+                Iniciar
               </Button>
             </div>
           </section>

--- a/src/app/routine/components/RoutineRunner.tsx
+++ b/src/app/routine/components/RoutineRunner.tsx
@@ -240,7 +240,7 @@ export function RoutineRunner({ routine }: RoutineRunnerProps) {
       <button
         onClick={handleSubmit}
         disabled={isSubmitting}
-        className="mt-8 w-full px-6 py-3 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+        className="mt-8 w-full px-6 py-3 max-md:mb-16 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
       >
         {isSubmitting ? "Enviando..." : "Finalizar rutina"}
       </button>

--- a/src/app/routine/layout.tsx
+++ b/src/app/routine/layout.tsx
@@ -9,7 +9,7 @@ export default function RoutineLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex pb-20 md:pb-0 bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
+    <div className="flex pb-20 md:pb-0 text-slate-50 bg-slate-950 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
       <Sidebar />
       <main className="flex-1">{children}</main>
     </div>

--- a/src/app/routine/layout.tsx
+++ b/src/app/routine/layout.tsx
@@ -9,9 +9,9 @@ export default function RoutineLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex">
+    <div className="flex pb-20 md:pb-0 bg-slate-950 text-slate-50 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]">
       <Sidebar />
-      <main className="flex-1 bg-slate-950">{children}</main>
+      <main className="flex-1">{children}</main>
     </div>
   );
 }

--- a/src/app/routine/layout.tsx
+++ b/src/app/routine/layout.tsx
@@ -1,5 +1,4 @@
 // app/dashboard/layout.tsx
-"use client";
 
 import React from "react";
 import Sidebar from "@/components/layout/Aside"; // confirma que en tu filesystem exista components/Sidebar.tsx

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -2,7 +2,7 @@
  * RoutinePage
  *
  * This is the main protected page where users can:
- * - View AI-generated recommended routines
+ * - View generated recommended routines
  * - Add routines manually or create custom ones
  * - Regenerate their plan if unsatisfied
  *
@@ -48,7 +48,7 @@ function RoutinePage() {
   if (ansError) {
     return (
       <div className="p-8 text-red-600 max-w-xl mx-auto">
-        Error loading profile data: {ansError.message}
+        Error cargando perfil: {ansError.message}
       </div>
     );
   }
@@ -56,8 +56,8 @@ function RoutinePage() {
   if (!answerId) {
     return (
       <div className="p-8 text-gray-600 max-w-xl mx-auto">
-        No routines found for your profile. Please complete the questionnaire
-        first.
+        No se encontraron rutinas para tu perfil. Por favor completa el cuestionario
+        primero.
       </div>
     );
   }

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -84,13 +84,13 @@ function RoutinePage() {
       {/* Regenerate prompt box */}
       <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 mt-8 shadow-sm">
         <h3 className="text-lg font-semibold text-white mb-2">
-          Not satisfied with the routines?
+          ¿No te satisface el plan?
         </h3>
         <p className="text-sm text-gray-400 mb-1">
-          You can regenerate them if they don’t fit your goals.
+          Puedes regenerarlas si no cumplen con tus objetivos.
         </p>
         <p className="text-sm text-gray-500 mb-4">
-          This action will replace all current routines. Proceed with caution.
+          Esta acción reemplazará todas las rutinas actuales. Procede con precaución.
         </p>
 
         <RegenerateButton answerId={answerId} />

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -47,7 +47,7 @@ function RoutinePage() {
 
   if (ansError) {
     return (
-      <div className="p-8 text-red-600 max-w-xl mx-auto">
+      <div className="p-4 md:p-8 text-red-600 max-w-xl mx-auto">
         Error cargando perfil: {ansError.message}
       </div>
     );
@@ -55,17 +55,27 @@ function RoutinePage() {
 
   if (!answerId) {
     return (
-      <div className="p-8 text-gray-600 max-w-xl mx-auto">
-        No se encontraron rutinas para tu perfil. Por favor completa el cuestionario
-        primero.
+      <div className="p-4 md:p-8 text-gray-600 max-w-xl mx-auto">
+        No se encontraron rutinas para tu perfil. Por favor completa el
+        cuestionario primero.
       </div>
     );
   }
 
   return (
-    <div className="max-w-7xl mx-auto p-8 bg-slate-950 gap-8 flex flex-col">
-      {/* Top right actions: add routine */}
-      <div className="flex gap-4 justify-end p-4">
+    // ===== 1. CONTENEDOR PRINCIPAL RESPONSIVE =====
+    <div className="max-w-7xl mx-auto p-4 md:p-8 bg-slate-950 gap-6 md:gap-8 flex flex-col">
+      {/* - p-4: Menos padding en móviles.
+        - md:p-8: El padding original para pantallas medianas y más grandes.
+        - gap-6 md:gap-8: Menos espaciado entre secciones en móvil.
+      */}
+
+      {/* ===== 2. BOTONES DE ACCIÓN RESPONSIVE ===== */}
+      <div className="flex flex-col sm:flex-row sm:justify-end gap-4">
+        {/* - flex-col: Los botones se apilan verticalmente en móviles.
+          - sm:flex-row: Vuelven a estar en fila en pantallas pequeñas y más grandes.
+          - sm:justify-end: Se alinean a la derecha a partir de ese tamaño.
+        */}
         <AddCustomRoutineDialog />
         <AddRoutineDialog
           answerId={answerId}
@@ -81,8 +91,11 @@ function RoutinePage() {
       {/* User-created custom routines */}
       <CustomRoutineList answerId={answerId} />
 
-      {/* Regenerate prompt box */}
-      <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 mt-8 shadow-sm">
+      {/* ===== 3. CAJA DE REGENERAR RESPONSIVE ===== */}
+      <div className="bg-gray-900 border border-gray-700 rounded-xl p-4 sm:p-6 mt-8 shadow-sm">
+        {/* - p-4: Menos padding en móviles.
+          - sm:p-6: El padding original para pantallas pequeñas y más grandes.
+        */}
         <h3 className="text-lg font-semibold text-white mb-2">
           ¿No te satisface el plan?
         </h3>
@@ -90,7 +103,8 @@ function RoutinePage() {
           Puedes regenerarlas si no cumplen con tus objetivos.
         </p>
         <p className="text-sm text-gray-500 mb-4">
-          Esta acción reemplazará todas las rutinas actuales. Procede con precaución.
+          Esta acción reemplazará todas las rutinas actuales. Procede con
+          precaución.
         </p>
 
         <RegenerateButton answerId={answerId} />

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -64,7 +64,7 @@ function RoutinePage() {
 
   return (
     // ===== 1. CONTENEDOR PRINCIPAL RESPONSIVE =====
-    <div className="max-w-7xl mx-auto p-4 md:p-8 bg-slate-950 gap-6 md:gap-8 flex flex-col">
+    <div className="max-w-7xl mx-auto p-4 md:p-8 text-slate-50 gap-6 md:gap-8 flex flex-col">
       {/* - p-4: Menos padding en móviles.
         - md:p-8: El padding original para pantallas medianas y más grandes.
         - gap-6 md:gap-8: Menos espaciado entre secciones en móvil.
@@ -92,7 +92,7 @@ function RoutinePage() {
       <CustomRoutineList answerId={answerId} />
 
       {/* ===== 3. CAJA DE REGENERAR RESPONSIVE ===== */}
-      <div className="bg-gray-900 border border-gray-700 rounded-xl p-4 sm:p-6 mt-8 shadow-sm">
+      <div className="bg-gray-900 border border-gray-700 rounded-xl p-4 sm:p-6 mt-8 shadow-sm text-slate-50">
         {/* - p-4: Menos padding en móviles.
           - sm:p-6: El padding original para pantallas pequeñas y más grandes.
         */}

--- a/src/components/layout/Aside.tsx
+++ b/src/components/layout/Aside.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation"; // 1. Cambiamos la importación
+import { usePathname, useRouter } from "next/navigation";
 import {
   Dumbbell,
   BarChart,
@@ -10,26 +10,42 @@ import {
   ListTree,
   User,
   Users,
+  Menu, // Icono para el menú
+  X, // Icono para cerrar
 } from "lucide-react";
-import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
 import useSWR from "swr";
+import { useState } from "react"; // Importamos useState
 
-// Array con la configuración de los enlaces de navegación
 const navLinks = [
   { href: "/routine", label: "Rutinas", icon: ListTree },
   { href: "/progress", label: "Progreso", icon: BarChart },
+  { href: "/community", label: "Comunidad", icon: Users },
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/profile", label: "Perfil", icon: User },
+];
+
+// Dividimos los enlaces para la nueva estructura móvil
+const mainNavLinks = [
+  { href: "/routine", label: "Rutinas", icon: ListTree },
+  { href: "/progress", label: "Progreso", icon: BarChart },
+];
+
+const secondaryNavLinks = [
   { href: "/groups", label: "Grupos", icon: Users },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/profile", label: "Perfil", icon: User },
 ];
 
 export default function Sidebar() {
-  // 2. Obtenemos la ruta actual
   const pathname = usePathname();
   const { user, supabase } = useAuth();
   const router = useRouter();
+
+  // Estado para controlar el menú desplegable móvil
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   // El estado 'isActive' ha sido eliminado
 
@@ -129,38 +145,96 @@ export default function Sidebar() {
 
       {/* Mobile navbar fixed bottom */}
       <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-700 flex justify-around p-1 md:hidden">
-        {navLinks.map((link) => {
-          // La misma lógica de comprobación
+        {/* Renderizamos los 3 enlaces principales */}
+        {mainNavLinks.map((link) => {
           const isActive = pathname.startsWith(link.href);
-
           return (
-            <Link key={link.href} href={link.href}>
+            <Link key={link.href} href={link.href} className="flex-1">
               <Button
                 variant="ghost"
-                size="icon"
-                // La misma lógica de clases condicionales
-                className={`
-                  flex flex-col h-14 w-16 rounded-md
-                  ${isActive ? "text-purple-400" : "text-gray-400"}
-                `}
+                className={`flex flex-col h-14 w-full rounded-md text-xs ${
+                  isActive ? "text-purple-400" : "text-gray-400"
+                }`}
               >
-                <link.icon className="w-5 h-5" />
-                <span className="text-xs mt-1">{link.label}</span>
+                <link.icon className="w-5 h-5 mb-1" />
+                {link.label}
               </Button>
             </Link>
           );
         })}
+
+        {/* Botón "Menú" que abre el panel */}
         <Button
           variant="ghost"
-          size="icon"
-          onClick={handleLogout}
-          className="text-red-400 hover:text-red-500 flex flex-col items-center h-full align-self-center"
+          onClick={() => setIsMobileMenuOpen(true)}
+          className="text-gray-400 flex flex-col flex-1 h-14 w-full rounded-md text-xs"
         >
-          <LogOut className="w-5 h-5" />
-
-          <span className="text-xs">Salir</span>
+          <Menu className="w-5 h-5 mb-1" />
+          <span>Menú</span>
         </Button>
       </nav>
+
+      {/* ===== PANEL DEL MENÚ MÓVIL (HAMBURGUESA) ===== */}
+      {isMobileMenuOpen && (
+        // Fondo oscuro semitransparente que cierra el menú al hacer clic
+        <div
+          className="fixed inset-0 bg-black/60 z-50 md:hidden"
+          onClick={() => setIsMobileMenuOpen(false)}
+        >
+          {/* Contenedor del panel que sube desde abajo */}
+          <div
+            className="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-700 rounded-t-lg p-4"
+            // Evita que hacer clic en el panel cierre el menú
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="font-bold text-white">Más Opciones</h3>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </Button>
+            </div>
+
+            {/* Lista de enlaces secundarios */}
+            <div className="flex flex-col space-y-2">
+              {secondaryNavLinks.map((link) => {
+                const isActive = pathname.startsWith(link.href);
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={() => setIsMobileMenuOpen(false)}
+                  >
+                    <Button
+                      variant="ghost"
+                      className={`w-full justify-start text-base p-4 ${
+                        isActive
+                          ? "bg-purple-600 text-white"
+                          : "text-gray-300 hover:bg-gray-800"
+                      }`}
+                    >
+                      <link.icon className="w-5 h-5 mr-3" />
+                      {link.label}
+                    </Button>
+                  </Link>
+                );
+              })}
+              {/* Botón de Salir */}
+              <Button
+                variant="ghost"
+                onClick={handleLogout}
+                className="w-full justify-start text-base p-4 text-red-400 hover:bg-red-500/20 hover:text-red-400"
+              >
+                <LogOut className="w-5 h-5 mr-3" />
+                Salir
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/layout/Aside.tsx
+++ b/src/components/layout/Aside.tsx
@@ -22,7 +22,7 @@ import { useState } from "react"; // Importamos useState
 const navLinks = [
   { href: "/routine", label: "Rutinas", icon: ListTree },
   { href: "/progress", label: "Progreso", icon: BarChart },
-  { href: "/community", label: "Comunidad", icon: Users },
+  { href: "/groups", label: "Grupos", icon: Users },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/profile", label: "Perfil", icon: User },
 ];

--- a/src/components/layout/Aside.tsx
+++ b/src/components/layout/Aside.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation"; // 1. Cambiamos la importación
 import {
   Dumbbell,
   BarChart,
@@ -12,30 +13,35 @@ import {
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 import { Button } from "@/components/ui/button";
-
-import { createClient } from "@/lib/supabase/supabaseClient";
 import { useAuth } from "@/context/AuthContext";
-import { useRouter } from "next/navigation";
 import useSWR from "swr";
 
+// Array con la configuración de los enlaces de navegación
+const navLinks = [
+  { href: "/routine", label: "Rutinas", icon: ListTree },
+  { href: "/progress", label: "Progreso", icon: BarChart },
+  { href: "/groups", label: "Grupos", icon: Users },
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/profile", label: "Perfil", icon: User },
+];
+
 export default function Sidebar() {
+  // 2. Obtenemos la ruta actual
+  const pathname = usePathname();
   const { user, supabase } = useAuth();
   const router = useRouter();
 
-  // 4. Usamos SWR para obtener los datos del perfil
-  // La 'key' depende del user.id. Si no hay usuario, la key es null y SWR no hace nada.
+  // El estado 'isActive' ha sido eliminado
+
   const { data: profile } = useSWR(
-    user ? `profile-${user.id}` : null, // Key única para SWR
+    user ? `profile-${user.id}` : null,
     async () => {
-      // El fetcher ahora es una función anónima aquí dentro
       const { data, error } = await supabase
         .from("profiles")
         .select("avatar_url, username")
-        .eq("id", user!.id) // Usamos '!' porque sabemos que 'user' existe si la key no es null
+        .eq("id", user!.id)
         .single();
-
       if (error) {
-        // No lanzamos un error para no romper toda la UI, solo lo logueamos
         console.error("Error fetching profile for sidebar:", error.message);
         return null;
       }
@@ -45,7 +51,7 @@ export default function Sidebar() {
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
-    router.push("/"); // Redirigimos al inicio después de cerrar sesión
+    router.push("/");
     router.refresh();
   };
 
@@ -59,128 +65,99 @@ export default function Sidebar() {
       {/* Desktop sidebar */}
       <aside className="hidden md:flex w-64 h-screen bg-gray-900 text-white flex-col justify-between sticky top-0">
         <div className="p-6">
-          <div
-            className="flex items-center gap-2 cursor-pointer"
-            onClick={() => (window.location.href = "/")}
-            role="link"
-            tabIndex={0}
-            onKeyDown={(e) => e.key === "Enter" && (window.location.href = "/")}
-          >
+          <Link href="/" className="flex items-center gap-2">
             <Dumbbell className="h-8 w-8 text-purple-400" />
             <h1 className="text-2xl font-bold">GymTracker Pro</h1>
-          </div>
+          </Link>
 
-          {/* Navigation Links */}
-          <nav className="mt-10 flex flex-col space-y-4">
-            <Link href="/routine">
-              <Button variant="ghost" className="justify-start w-full">
-                <ListTree className="w-5 h-5 mr-2" /> Rutinas
-              </Button>
-            </Link>
-            <Link href="/progress">
-              <Button variant="ghost" className="justify-start w-full">
-                <BarChart className="w-5 h-5 mr-2" /> Progreso
-              </Button>
-            </Link>
-            <Link href="/groups">
-              <Button variant="ghost" className="justify-start w-full">
-                <Users className="w-5 h-5 mr-2" /> Grupos
-              </Button>
-            </Link>
-            <Link href="/dashboard">
-              <Button variant="ghost" className="justify-start w-full">
-                <LayoutDashboard className="w-5 h-5 mr-2" /> Dashboard
-              </Button>
-            </Link>
-            <Link href="/profile">
-              <Button variant="ghost" className="justify-start w-full">
-                <User className="w-5 h-5 mr-2" /> Perfil
-              </Button>
-            </Link>
+          {/* Navigation Links (renderizados desde el array) */}
+          <nav className="mt-10 flex flex-col space-y-2">
+            {navLinks.map((link) => {
+              // 3. Comprobamos si el enlace está activo
+              const isActive = pathname.startsWith(link.href);
+
+              return (
+                <Link key={link.href} href={link.href}>
+                  <Button
+                    variant="ghost"
+                    // 4. Aplicamos clases condicionales
+                    className={`
+                      w-full justify-start text-base p-6
+                      ${
+                        isActive
+                          ? "bg-white text-black hover:bg-gray-200"
+                          : "hover:bg-gray-400"
+                      }
+                    `}
+                  >
+                    <link.icon className="w-5 h-5 mr-3" />
+                    {link.label}
+                  </Button>
+                </Link>
+              );
+            })}
           </nav>
         </div>
 
-        {/* Avatar and logout */}
-        <div className="p-4 gap-6 flex">
-          <Avatar className="w-40 h-20">
+        {/* Avatar and logout (sin cambios) */}
+        <div className="p-4 border-t border-gray-700 flex items-center gap-4">
+          <Avatar>
             <AvatarImage
-              className="rounded-full size-20"
+              className="rounded-full w-24 h-22"
               src={profile?.avatar_url || undefined}
               alt="User Avatar"
             />
             <AvatarFallback>{fallbackLetter}</AvatarFallback>
           </Avatar>
-          <div className="text-sm font-medium w-full text-center m-2">
-            Hola, <span className="font-bold text-white">{user?.email}</span>
+          <div className="text-sm flex flex-col w-full justify-center text-center gap-2">
+            <p className="font-bold text-white truncate">
+              <span className="font-normal">Hola, </span>
+              {profile?.username || user?.email}
+            </p>
             <Button
-              className="px-4 py-2 rounded hover:text-white hover:bg-red-500 w-full mt-2 bg-white text-black"
+              variant="outline"
               onClick={handleLogout}
+              className="text-red-400 hover:text-red-500 flex items-center w-full"
             >
-              Cerrar sesión
+              <LogOut className="w-5 h-5" />
+
+              <span className="text-xs">Salir</span>
             </Button>
           </div>
         </div>
       </aside>
 
       {/* Mobile navbar fixed bottom */}
-      <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-700 flex justify-around items-center p-2 md:hidden">
-        <Link href="/routine">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white flex flex-col items-center"
-          >
-            <ListTree className="w-5 h-5" />
-            <span className="text-xs">Rutinas</span>
-          </Button>
-        </Link>
-        <Link href="/progress">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white flex flex-col items-center"
-          >
-            <BarChart className="w-5 h-5" />
-            <span className="text-xs">Progreso</span>
-          </Button>
-        </Link>{" "}
-        <Link href="/groups">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white flex flex-col items-center"
-          >
-            <Users className="w-5 h-5" />
-            <span className="text-xs">Grupos</span>
-          </Button>
-        </Link>{" "}
-        <Link href="/dashboard">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white flex flex-col items-center"
-          >
-            <LayoutDashboard className="w-5 h-5" />
-            <span className="text-xs">Dashboard</span>
-          </Button>
-        </Link>{" "}
-        <Link href="/profile">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-white flex flex-col items-center"
-          >
-            <User className="w-5 h-5" />
-            <span className="text-xs">Perfil</span>
-          </Button>
-        </Link>
+      <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-700 flex justify-around p-1 md:hidden">
+        {navLinks.map((link) => {
+          // La misma lógica de comprobación
+          const isActive = pathname.startsWith(link.href);
+
+          return (
+            <Link key={link.href} href={link.href}>
+              <Button
+                variant="ghost"
+                size="icon"
+                // La misma lógica de clases condicionales
+                className={`
+                  flex flex-col h-14 w-16 rounded-md
+                  ${isActive ? "text-purple-400" : "text-gray-400"}
+                `}
+              >
+                <link.icon className="w-5 h-5" />
+                <span className="text-xs mt-1">{link.label}</span>
+              </Button>
+            </Link>
+          );
+        })}
         <Button
           variant="ghost"
           size="icon"
           onClick={handleLogout}
-          className="text-red-400 hover:text-red-500 flex flex-col items-center"
+          className="text-red-400 hover:text-red-500 flex flex-col items-center h-full align-self-center"
         >
           <LogOut className="w-5 h-5" />
+
           <span className="text-xs">Salir</span>
         </Button>
       </nav>

--- a/src/components/layout/Main.tsx
+++ b/src/components/layout/Main.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 
 export default function Main() {
   return (
-    <div className="min-h-screen bg-[var(--background-color)] text-white">
+    <div className="bg-[var(--background-color)] text-white">
       {/* Application Navigation Bar */}
       <Navbar />
 


### PR DESCRIPTION
Key changes include:

1.  **Global Layout (`layout.tsx`):**
    - Added responsive bottom padding (`pb-20 md:pb-0`) to the main content area. This prevents the fixed mobile bottom navigation bar from overlapping content on all pages.

2.  **Sidebar & Mobile Nav (`Sidebar.tsx`):**
    - Implemented active link styling using the `usePathname` hook to visually highlight the current page in the navigation.
    - Refactored the mobile navigation for small viewports: it now displays the main links and a "Menu" (hamburger) button that opens a panel with secondary options, preventing UI clutter on narrow screens.
    - Polished the desktop sidebar's user profile section by correcting the avatar's aspect ratio and improving text alignment for a cleaner look.

3.  **Dashboard Page (`DashboardPage.tsx`):**
    - Converted the main content area to a responsive grid (`grid-cols-1 lg:grid-cols-2`). Cards now stack neatly on mobile and sit side-by-side on larger screens, optimizing space.
    - The page header now stacks vertically on mobile for better readability.

4.  **Dashboard Answer Card (`AnswerCard.tsx`):**
    - Refactored the inner `InfoBlock` container to use a responsive grid. This ensures the stat cards are full-width and symmetrical on mobile (`grid-cols-1`), and form a multi-column layout on larger screens, as requested.

5.  **Routine Page (`RoutinePage.tsx`):**
    - Applied responsive padding and gaps to the main container.
    - Action buttons are now stacked vertically on mobile to improve usability and tap-target size.
